### PR TITLE
Coupling_id type fix

### DIFF
--- a/examples/dcap.jl
+++ b/examples/dcap.jl
@@ -89,11 +89,11 @@ function main_dcap(nR::Int, nN::Int, nT::Int, nS::Int, seed::Int=1)
       model = models[s]
       xref = model[:x]
       for i in sR, t in sT
-          push!(coupling_variables, DD.CouplingVariableRef(s, (i,t), xref[i,t]))
+          push!(coupling_variables, DD.CouplingVariableRef(s, (1,i,t), xref[i,t]))
       end
       uref = model[:u]
       for i in sR, t in sT
-          push!(coupling_variables, DD.CouplingVariableRef(s, (i,t), uref[i,t]))
+          push!(coupling_variables, DD.CouplingVariableRef(s, (2,i,t), uref[i,t]))
       end
   end
 

--- a/src/BlockModel.jl
+++ b/src/BlockModel.jl
@@ -43,7 +43,7 @@ mutable struct BlockModel <: AbstractBlockModel
 
     # TODO: These may be available with heuristics.
     primal_bound::Float64
-    primal_solution::Dict{Int, Float64} #coupling_id : value 
+    primal_solution::Dict{Any, Float64} #coupling_id : value 
     combined_weights::Dict{Int, Float64} # block_id : value 
     record::Dict{Any, Any}
 

--- a/test/heuristics.jl
+++ b/test/heuristics.jl
@@ -38,7 +38,7 @@
                 model = models[s]
                 xref = model[:x]
                 for i in CROPS
-                    push!(coupling_variables, DD.CouplingVariableRef(s, i, xref[i]))
+                    push!(coupling_variables, DD.CouplingVariableRef(s, "x$i", xref[i]))
                 end
             end
 


### PR DESCRIPTION
The type for `primal_solution` is supposed to be `Dict{Any, Float64}` instead of `Dict{Int, Float64}`, to allow general coupling_id types. This happens when the coupling ID is set to `'y'`, for example in  #52. 

Also, coupling_id in dcap example was not defined properly, which is fixed.

Finally, heuristics.jl is modified to use string coupling_id to test if the modification works.