### PR TITLE
Save subproblem solutions

### DIFF
--- a/examples/dcap.jl
+++ b/examples/dcap.jl
@@ -89,11 +89,11 @@ function main_dcap(nR::Int, nN::Int, nT::Int, nS::Int, seed::Int=1)
       model = models[s]
       xref = model[:x]
       for i in sR, t in sT
-          push!(coupling_variables, DD.CouplingVariableRef(s, (i,t), xref[i,t]))
+          push!(coupling_variables, DD.CouplingVariableRef(s, (1,i,t), xref[i,t]))
       end
       uref = model[:u]
       for i in sR, t in sT
-          push!(coupling_variables, DD.CouplingVariableRef(s, (i,t), uref[i,t]))
+          push!(coupling_variables, DD.CouplingVariableRef(s, (2,i,t), uref[i,t]))
       end
   end
 

--- a/src/BlockModel.jl
+++ b/src/BlockModel.jl
@@ -35,6 +35,7 @@ abstract type AbstractBlockModel end
 
 mutable struct BlockModel <: AbstractBlockModel
     model::Dict{Int,JuMP.Model} # Dictionary of block models
+    block_solutions::Dict{Int,Dict{Any,Float64}} #block_id : VariableRef : value
     coupling_variables::Vector{CouplingVariableRef} # array of variables that couple block models
     variables_by_couple::Dict{Any,Vector{CouplingVariableKey}} # maps `couple_id` to `CouplingVariableKey`
 
@@ -49,6 +50,7 @@ mutable struct BlockModel <: AbstractBlockModel
 
     function BlockModel()
         return new(
+            Dict(), 
             Dict(), 
             [],
             Dict(),
@@ -68,6 +70,7 @@ Add block model `model` to `block_model::AbstractBlockModel` with `block_id`.
 """
 function add_block_model!(block_model::AbstractBlockModel, block_id::Integer, model::JuMP.Model)
     block_model.model[block_id] = model
+    block_model.block_solutions[block_id] = Dict()
 end
 
 """
@@ -90,6 +93,13 @@ block_model(block_model::AbstractBlockModel) = block_model.model
 This returns a `JuMP.Model` object for a given `block_id`.
 """
 block_model(block_model::AbstractBlockModel, block_id::Integer) = block_model.model[block_id]
+
+"""
+    block_solutions
+
+This returns a dictionary of `JuMP.VariableRef` solutions.
+"""
+block_solutions(block_model::AbstractBlockModel, block_id::Integer) = block_model.block_solutions[block_id]
 
 """
     has_block_model

--- a/src/BlockModel.jl
+++ b/src/BlockModel.jl
@@ -43,7 +43,7 @@ mutable struct BlockModel <: AbstractBlockModel
 
     # TODO: These may be available with heuristics.
     primal_bound::Float64
-    primal_solution::Dict{Int, Float64} #coupling_id : value 
+    primal_solution::Dict{Any, Float64} #coupling_id : value 
     combined_weights::Dict{Int, Float64} # block_id : value 
     record::Dict{Any, Any}
 

--- a/src/LagrangeDual.jl
+++ b/src/LagrangeDual.jl
@@ -39,6 +39,7 @@ add_block_model!(LD::AbstractLagrangeDual, block_id::Integer, model::JuMP.Model)
 num_blocks(LD::AbstractLagrangeDual) = num_blocks(LD.block_model)
 block_model(LD::AbstractLagrangeDual, block_id::Integer) = block_model(LD.block_model, block_id)
 block_model(LD::AbstractLagrangeDual) = block_model(LD.block_model)
+block_solutions(LD::AbstractLagrangeDual, block_id::Integer) = block_solutions(LD.block_model, block_id)
 has_block_model(LD::AbstractLagrangeDual, block_id::Integer) = has_block_model(LD.block_model, block_id)
 num_coupling_variables(LD::AbstractLagrangeDual) = num_coupling_variables(LD.block_model)
 coupling_variables(LD::AbstractLagrangeDual) = coupling_variables(LD.block_model)
@@ -114,6 +115,10 @@ function run!(LD::AbstractLagrangeDual, LM::AbstractLagrangeMaster, initial_λ =
             # We may want consider other statuses.
             if status in [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
                 objvals[id] = -JuMP.objective_value(m)
+                av = JuMP.all_variables(m)
+                for v in av
+                    block_solutions(LD, id)[string(v)] = JuMP.value(v)
+                end
             else
                 @error "Unexpected solution status: $(status)"
             end

--- a/test/heuristics.jl
+++ b/test/heuristics.jl
@@ -38,7 +38,7 @@
                 model = models[s]
                 xref = model[:x]
                 for i in CROPS
-                    push!(coupling_variables, DD.CouplingVariableRef(s, i, xref[i]))
+                    push!(coupling_variables, DD.CouplingVariableRef(s, "x$i", xref[i]))
                 end
             end
 


### PR DESCRIPTION
As mentioned in #54, there is no standard way to access the subproblem solutions once the algorithm is terminated. This code saves the solutions in LD.